### PR TITLE
feat!: Redefine the `relocate` lifecycle algorithm

### DIFF
--- a/src/MountedPiece.ts
+++ b/src/MountedPiece.ts
@@ -1,6 +1,6 @@
 import { mountPieceKey } from "./common.js";
 import { Stack } from "./Stack.js";
-import type { Mount, CorePiece, UnmountFn, Update, MountPiece, AcceptableTarget, CorePieceCapabilities, Relocate, RelocationResult } from "./types.js";
+import type { Mount, CorePiece, UnmountFn, Update, MountPiece, AcceptableTarget, CorePieceCapabilities, Relocate, RelocationResult, RelocationRollbackFn, RelocationResultValue } from "./types.js";
 
 export const mountKey = Symbol();
 
@@ -35,25 +35,65 @@ async function doUpdate<TProps extends Record<string, any> = Record<string, any>
     return await update(props);
 }
 
-async function doRelocate(relocate: Relocate, target: AcceptableTarget, newTarget: AcceptableTarget): Promise<RelocationResult> {
-    if (Array.isArray(relocate)) {
-        let first = true;
-        let ready = false;
-        for (const fn of relocate) {
-            const r = await doRelocate(fn, target, newTarget);
-            if (r === 'ready') {
-                ready = true;
-            } else if (!r) {
-                if (first) {
-                    return false;
-                }
-                throw new Error("Relocation function returned 'false' after another relocation function returned 'ready' or 'true'.  The piece's state is now inconsistent.");
-            }
-            first = false;
-        }
-        return ready ? 'ready' : true;
+function relocationResultValue(result: RelocationResult): RelocationResultValue {
+    if (Array.isArray(result)) {
+        return result[0];
     }
-    return await relocate(target, newTarget);
+    return result;
+}
+
+async function doRelocate(relocate: Relocate, target: AcceptableTarget, newTarget: AcceptableTarget): Promise<RelocationResultValue | Stack<RelocationRollbackFn>> {
+    const rollbackFns: Stack<RelocationRollbackFn> = new Stack<RelocationRollbackFn>();
+    let safeState = true;
+    const doRelocateInternal = async (rel: Relocate): Promise<RelocationResultValue> => {
+        const maybePushRollback = (result: RelocationResult) => {
+            if (Array.isArray(result) && (result[0] === 'done' || result[0] === 'supported')) {
+                rollbackFns.push(result[1]);
+            }
+            else if (result === 'done') {
+                safeState = false;
+            }
+        };
+        if (Array.isArray(rel)) {
+            let supported = false;
+            for (const fn of rel) {
+                const r = await doRelocateInternal(fn);
+                const rValue = relocationResultValue(r);
+                if (rValue === 'supported') {
+                    supported = true;
+                } else if (rValue === 'unsupported') {
+                    if (safeState) {
+                        while (rollbackFns.size) {
+                            await rollbackFns.pop()?.();
+                        }
+                        return 'unsupported';
+                    }
+                    throw new Error("Relocation function returned 'unsupported' after another relocation function returned 'done' without a rollback.  The piece's state is now inconsistent.");
+                }
+            }
+            return supported ? 'supported' : 'done';
+        }
+        try {
+            const r = await rel(target, newTarget);
+            maybePushRollback(r);
+            return relocationResultValue(r);
+        }
+        catch (error) {
+            if (safeState) {
+                while (rollbackFns.size) {
+                    await rollbackFns.pop()?.();
+                }
+                console.warn("Relocation function failed.  Piece relocation has been rolled back.", error);
+                return 'unsupported';
+            }
+            throw new Error("Relocation function failed after another relocation function returned 'done' without a rollback.  The piece's state is now inconsistent.");
+        }
+    };
+    const internalResult = await doRelocateInternal(relocate);
+    if (rollbackFns.size > 0 && relocationResultValue(internalResult) === 'supported') {
+        return rollbackFns;
+    }
+    return internalResult;
 }
 
 export class MountedPiece<
@@ -84,7 +124,7 @@ export class MountedPiece<
     }
 
     async [mountKey](target: AcceptableTarget, props?: TProps) {
-        this.#cleanup = await doMount(this.#piece.mount, target, {...(props as TProps), [mountPieceKey]: this.#mountPiece});
+        this.#cleanup = await doMount(this.#piece.mount, target, { ...(props as TProps), [mountPieceKey]: this.#mountPiece });
         if (this.#parent) {
             this.#parent.#childPieces.push(this);
         }
@@ -107,11 +147,30 @@ export class MountedPiece<
         return doUpdate(this.#piece.update, props);
     }
 
-    relocate(target: AcceptableTarget, newTarget: AcceptableTarget) {
+    async relocate(target: AcceptableTarget, newTarget: AcceptableTarget, customRelocate?: (source: AcceptableTarget, target: AcceptableTarget) => Promise<boolean>) {
         if (!this.#piece.relocate) {
             return Promise.resolve(false);
         }
-        return doRelocate(this.#piece.relocate, target, newTarget);
+        const result = await doRelocate(this.#piece.relocate, target, newTarget);
+        if (result === 'done') {
+            return true;
+        }
+        if (result === 'unsupported') {
+            return false;
+        }
+        if (result === 'supported') {
+            return await customRelocate?.(target, newTarget) ?? false;
+        }
+        try {
+            return await customRelocate?.(target, newTarget) ?? false;
+        }
+        catch (error) {
+            while (result.size) {
+                await result.pop()?.();
+            }
+            console.warn("Custom relocation function failed.  Piece relocation has been rolled back.", error);
+            return false;
+        }
     }
 
     get capabilities() {

--- a/src/MountedPiece.ts
+++ b/src/MountedPiece.ts
@@ -90,7 +90,7 @@ async function doRelocate(relocate: Relocate, target: AcceptableTarget, newTarge
         }
     };
     const internalResult = await doRelocateInternal(relocate);
-    if (rollbackFns.size > 0 && relocationResultValue(internalResult) === 'supported') {
+    if (rollbackFns.size > 0 && relocationResultValue(internalResult) === 'supported' && safeState) {
         return rollbackFns;
     }
     return internalResult;
@@ -158,11 +158,15 @@ export class MountedPiece<
         if (result === 'unsupported') {
             return false;
         }
+        // At this point, custom relocation must finish the job.
+        if (!customRelocate) {
+            throw new Error("Relocation of this piece is 'supported', but no custom relocation function was provided.");
+        }
         if (result === 'supported') {
-            return await customRelocate?.(target, newTarget) ?? false;
+            return await customRelocate(target, newTarget);
         }
         try {
-            return await customRelocate?.(target, newTarget) ?? false;
+            return await customRelocate(target, newTarget);
         }
         catch (error) {
             while (result.size) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { mountPieceKey } from './common.js';
 export { ensureGlobalCollageJs } from './global.js';
 export { preventRemount } from './preventRemount.js';
 export { noopPiece } from './noopPiece.js';
+export { Stack } from './Stack.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,16 +21,26 @@ export type UnmountFn = () => Promise<void>;
  */
 export type MountFn<TProps extends Record<string, any> = Record<string, any>> = (target: AcceptableTarget, props?: MountProps<TProps>) => Promise<UnmountFn>;
 /**
+ * Supported return values of `CorePiece.relocate` functions.
+ */
+export type RelocationResultValue = 'supported' | 'unsupported' | 'done';
+/**
+ * Defines the signature of rollback functions that can be returned by `CorePiece.relocate` functions.  These functions
+ * can be provided when returning `done` or `supported` from a relocation function, and will be called if the
+ * relocation chain fails.
+ * @returns A promise that resolves once the rollback process concludes.
+ */
+export type RelocationRollbackFn = () => Promise<void>;
+/**
  * Defines the possible return values of `CorePiece.relocate`.
  */
-export type RelocationResult = boolean | 'ready';
+export type RelocationResult = RelocationResultValue | [Exclude<RelocationResultValue, 'unsupported'>, RelocationRollbackFn];
 /**
  * Type that defines the signature of the functions accepted in `CorePiece.relocate`.
  * @param parent The current parent of the piece's root element(s).
  * @param newParent The new parent where the piece's root element(s) will be relocated.
- * @returns A promise that resolves to `true` if the relocation was successful, `false` if it failed or relocation
- * is disallowed, or `'ready'` if the piece is ready to be relocated, but the relocation must be performed by the
- * caller.
+ * @returns A promise that resolves to one of the acceptable values.  See `RelocationResult` and related types for
+ * details.
  */
 export type RelocateFn = (parent: AcceptableTarget, newParent: AcceptableTarget) => Promise<RelocationResult>;
 /**
@@ -88,23 +98,34 @@ export interface CorePiece<
     /**
      * Either relocates the root element(s) of the piece to a new parent, or prepares the piece for relocation.  This
      * is optional.  If not provided, the piece won't support relocation of its root element(s) to a new parent, and
-     * the piece will be unmounted and remounted instead in the pertinent cases.
+     * the piece will be unmounted and remounted instead in pertinent cases.
      *
      * ### Return Values
      *
-     * + `true`:  The relocation was successful.
-     * + `false`:  The relocation failed or is disallowed.
-     * + `'ready'`:  The piece is ready to be relocated, but the relocation must be performed by the caller.
+     * + `done`:  The relocation succeeded and was made entirely by the piece.
+     * + `unsupported`:  The piece does not support relocation.
+     * + `supported`:  The piece supports relocation, but the relocation must be performed by the caller.
+     *
+     * Additionally, the values `done` and `supported` can be returned as a tuple with a rollback function that will be
+     * called if the relocation chain fails after this function has returned `done` or `supported`.
+     *
+     * ### Rollback Functions
+     *
+     * If a relocation function returns a rollback function, it will be called if any of the following occurs:
+     *
+     * + Another relocation function returns `unsupported` after this one returned `done` or `supported`.
+     * + Another relocation function throws an error after this one returned `done` or `supported`.
      *
      * ### When Using Multiple Relocation Functions
      *
      * If multiple relocation functions are provided, they will be called in order:
      *
-     * + If the first of them returns `false`, the relocation process will stop.
-     * + If all of them return `true`, the relocation is considered successful.
-     * + If any of them returns `'ready'`, the remaining functions are still called, but the caller will
-     * run its relocation process after all functions have been called.
-     * + If any of them returns `false` after one or more of them returned `'ready'` or `true`, an error is thrown.
+     * + If the first of them returns `unsupported`, the relocation process will stop.
+     * + If all of them return `done`, the relocation is considered successful.
+     * + If any of them returns `'supported'`, the remaining functions are still called, but the caller will
+     * run its relocation process after all functions have been called, even if they return `'done'`.
+     * + If any of them returns `unsupported` after one or more of them returned `'supported'` or `done` without a
+     * rollback function, the piece's state is considered inconsistent and an error will be thrown.
      */
     relocate?: Relocate;
     /**
@@ -147,7 +168,7 @@ export interface MountedPiece<
     /**
      * Function used to relocate the `CorePiece` object to a new parent without unmounting.
      */
-    relocate: RelocateFn;
+    relocate: (source: AcceptableTarget, target: AcceptableTarget, customRelocate?: (source: AcceptableTarget, target: AcceptableTarget) => Promise<boolean>) => Promise<boolean>;
     /**
      * The version of the global `mountPiece` function that tracks mounted children so their unmounting is
      * synchronized with this piece's unmount event.

--- a/tests/ut/MountedPiece.test.ts
+++ b/tests/ut/MountedPiece.test.ts
@@ -237,12 +237,12 @@ function testPrefix(shadow: boolean) {
             expect(target2.children.length).to.equal(0);
         });
         describe(`${testPrefix(shadow)}relocate()`, () => {
-            it(`${testPrefix(shadow)}Should handle relocation of a piece.`, async () => {
+            it(`${testPrefix(shadow)}Should return true when relocation is done by the piece.`, async () => {
                 const initialTarget = createTarget(shadow);
                 const newTarget = createTarget(shadow);
                 const piece = {
                     mount: vi.fn(),
-                    relocate: vi.fn().mockReturnValue(Promise.resolve(true))
+                    relocate: vi.fn().mockResolvedValue('done')
                 };
                 const mp = new MountedPiece(piece, mountPieceCore);
                 await mp[mountKey](initialTarget);
@@ -250,6 +250,7 @@ function testPrefix(shadow: boolean) {
                 expect(result).to.be.true;
                 expect(piece.relocate).toHaveBeenCalledWith(initialTarget, newTarget);
             });
+
             it(`${testPrefix(shadow)}Should return false when relocating a piece without a relocate function.`, async () => {
                 const initialTarget = createTarget(shadow);
                 const newTarget = createTarget(shadow);
@@ -261,11 +262,44 @@ function testPrefix(shadow: boolean) {
                 const result = await mp.relocate(initialTarget, newTarget);
                 expect(result).to.be.false;
             });
-            it(`${testPrefix(shadow)}Should handle array of relocation functions.`, async () => {
+
+            it(`${testPrefix(shadow)}Should return false when caller relocation is required but not provided.`, async () => {
                 const initialTarget = createTarget(shadow);
                 const newTarget = createTarget(shadow);
-                const relocateFn1 = vi.fn().mockResolvedValue(true);
-                const relocateFn2 = vi.fn().mockResolvedValue(true);
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: vi.fn().mockResolvedValue('supported')
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                await expect(mp.relocate(initialTarget, newTarget)).resolves.toBe(false);
+            });
+
+            it(`${testPrefix(shadow)}Should return the caller relocation result when the piece supports relocation.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const customRelocate = vi.fn().mockResolvedValue(true);
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: vi.fn().mockResolvedValue('supported')
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                const result = await mp.relocate(initialTarget, newTarget, customRelocate);
+
+                expect(result).to.be.true;
+                expect(customRelocate).toHaveBeenCalledWith(initialTarget, newTarget);
+            });
+
+            it(`${testPrefix(shadow)}Should handle arrays when every relocation function returns done.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const relocateFn1 = vi.fn().mockResolvedValue('done');
+                const relocateFn2 = vi.fn().mockResolvedValue('done');
                 const piece = {
                     mount: vi.fn(),
                     relocate: [relocateFn1, relocateFn2]
@@ -277,11 +311,12 @@ function testPrefix(shadow: boolean) {
                 expect(relocateFn2).toHaveBeenCalledWith(initialTarget, newTarget);
                 expect(result).to.be.true;
             });
-            it(`${testPrefix(shadow)}Should return false if the first relocation function returns false.`, async () => {
+
+            it(`${testPrefix(shadow)}Should stop early when the first relocation function returns unsupported.`, async () => {
                 const initialTarget = createTarget(shadow);
                 const newTarget = createTarget(shadow);
-                const relocateFn1 = vi.fn().mockResolvedValue(false);
-                const relocateFn2 = vi.fn().mockResolvedValue(true);
+                const relocateFn1 = vi.fn().mockResolvedValue('unsupported');
+                const relocateFn2 = vi.fn().mockResolvedValue('done');
                 const piece = {
                     mount: vi.fn(),
                     relocate: [relocateFn1, relocateFn2]
@@ -293,36 +328,152 @@ function testPrefix(shadow: boolean) {
                 expect(relocateFn2).not.toHaveBeenCalled();
                 expect(result).to.be.false;
             });
-            it(`${testPrefix(shadow)}Should return 'ready' even if not all relocation functions return it.`, async () => {
+
+            it(`${testPrefix(shadow)}Should call the caller relocation after supported and done results are combined.`, async () => {
                 const initialTarget = createTarget(shadow);
                 const newTarget = createTarget(shadow);
-                const relocateFn1 = vi.fn().mockResolvedValue('ready');
-                const relocateFn2 = vi.fn().mockResolvedValue(true);
+                const customRelocate = vi.fn().mockResolvedValue(true);
+                const relocateFn1 = vi.fn().mockResolvedValue('supported');
+                const relocateFn2 = vi.fn().mockResolvedValue('done');
                 const piece = {
                     mount: vi.fn(),
                     relocate: [relocateFn1, relocateFn2]
                 };
                 const mp = new MountedPiece(piece, mountPieceCore);
                 await mp[mountKey](initialTarget);
-                const result = await mp.relocate(initialTarget, newTarget);
+                const result = await mp.relocate(initialTarget, newTarget, customRelocate);
                 expect(relocateFn1).toHaveBeenCalledWith(initialTarget, newTarget);
                 expect(relocateFn2).toHaveBeenCalledWith(initialTarget, newTarget);
-                expect(result).to.equal('ready');
+                expect(customRelocate).toHaveBeenCalledWith(initialTarget, newTarget);
+                expect(result).to.be.true;
             });
-            [true, 'ready'].forEach(tc => {
-                it(`${testPrefix(shadow)}Should throw an error if a relocation function returns 'false' after another returned '${tc}'.`, async () => {
-                    const initialTarget = createTarget(shadow);
-                    const newTarget = createTarget(shadow);
-                    const relocateFn1 = vi.fn().mockResolvedValue(tc);
-                    const relocateFn2 = vi.fn().mockResolvedValue(false);
-                    const piece = {
-                        mount: vi.fn(),
-                        relocate: [relocateFn1, relocateFn2]
-                    };
-                    const mp = new MountedPiece(piece, mountPieceCore);
-                    await mp[mountKey](initialTarget);
-                    await expect(mp.relocate(initialTarget, newTarget)).rejects.toThrow();
+
+            it(`${testPrefix(shadow)}Should rollback and return false when unsupported happens after rollbackable supported.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const rollback = vi.fn().mockResolvedValue(undefined);
+                const relocateFn1 = vi.fn().mockResolvedValue(['supported', rollback]);
+                const relocateFn2 = vi.fn().mockResolvedValue('unsupported');
+                const customRelocate = vi.fn().mockResolvedValue(true);
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: [relocateFn1, relocateFn2]
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                const result = await mp.relocate(initialTarget, newTarget, customRelocate);
+
+                expect(result).to.be.false;
+                expect(rollback).toHaveBeenCalledOnce();
+                expect(customRelocate).not.toHaveBeenCalled();
+            });
+
+            it(`${testPrefix(shadow)}Should rollback and return false when unsupported happens after rollbackable done.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const rollback = vi.fn().mockResolvedValue(undefined);
+                const relocateFn1 = vi.fn().mockResolvedValue(['done', rollback]);
+                const relocateFn2 = vi.fn().mockResolvedValue('unsupported');
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: [relocateFn1, relocateFn2]
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                const result = await mp.relocate(initialTarget, newTarget);
+
+                expect(result).to.be.false;
+                expect(rollback).toHaveBeenCalledOnce();
+            });
+
+            it(`${testPrefix(shadow)}Should throw when unsupported happens after done without rollback.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const relocateFn1 = vi.fn().mockResolvedValue('done');
+                const relocateFn2 = vi.fn().mockResolvedValue('unsupported');
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: [relocateFn1, relocateFn2]
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                await expect(mp.relocate(initialTarget, newTarget)).rejects.toThrow(/state is now inconsistent/i);
+            });
+
+            it(`${testPrefix(shadow)}Should rollback and return false when a relocation function throws in a safe state.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const rollback = vi.fn().mockResolvedValue(undefined);
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+                const relocateFn1 = vi.fn().mockResolvedValue(['supported', rollback]);
+                const relocateFn2 = vi.fn().mockRejectedValue(new Error('boom'));
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: [relocateFn1, relocateFn2]
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                const result = await mp.relocate(initialTarget, newTarget);
+
+                expect(result).to.be.false;
+                expect(rollback).toHaveBeenCalledOnce();
+                expect(warnSpy).toHaveBeenCalledOnce();
+                warnSpy.mockRestore();
+            });
+
+            it(`${testPrefix(shadow)}Should throw when a relocation function throws after done without rollback.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const relocateFn1 = vi.fn().mockResolvedValue('done');
+                const relocateFn2 = vi.fn().mockRejectedValue(new Error('boom'));
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: [relocateFn1, relocateFn2]
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                await expect(mp.relocate(initialTarget, newTarget)).rejects.toThrow(/state is now inconsistent/i);
+            });
+
+            it(`${testPrefix(shadow)}Should rollback caller relocation failures in LIFO order.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const callOrder: string[] = [];
+                const rollback1 = vi.fn().mockImplementation(async () => {
+                    callOrder.push('rollback-1');
                 });
+                const rollback2 = vi.fn().mockImplementation(async () => {
+                    callOrder.push('rollback-2');
+                });
+                const customRelocate = vi.fn().mockRejectedValue(new Error('custom-boom'));
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: [
+                        vi.fn().mockResolvedValue(['supported', rollback1]),
+                        vi.fn().mockResolvedValue(['done', rollback2])
+                    ]
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                const result = await mp.relocate(initialTarget, newTarget, customRelocate);
+
+                expect(result).to.be.false;
+                expect(callOrder).to.deep.equal(['rollback-2', 'rollback-1']);
+                expect(warnSpy).toHaveBeenCalledOnce();
+                warnSpy.mockRestore();
             });
         });
         describe(`${testPrefix(shadow)}Capabilities`, () => {

--- a/tests/ut/MountedPiece.test.ts
+++ b/tests/ut/MountedPiece.test.ts
@@ -263,7 +263,7 @@ function testPrefix(shadow: boolean) {
                 expect(result).to.be.false;
             });
 
-            it(`${testPrefix(shadow)}Should return false when caller relocation is required but not provided.`, async () => {
+            it(`${testPrefix(shadow)}Should throw when caller relocation is required but not provided.`, async () => {
                 const initialTarget = createTarget(shadow);
                 const newTarget = createTarget(shadow);
                 const piece = {
@@ -274,7 +274,7 @@ function testPrefix(shadow: boolean) {
                 const mp = new MountedPiece(piece, mountPieceCore);
                 await mp[mountKey](initialTarget);
 
-                await expect(mp.relocate(initialTarget, newTarget)).resolves.toBe(false);
+                await expect(mp.relocate(initialTarget, newTarget)).rejects.toThrow(/no custom relocation function was provided/i);
             });
 
             it(`${testPrefix(shadow)}Should return the caller relocation result when the piece supports relocation.`, async () => {
@@ -474,6 +474,27 @@ function testPrefix(shadow: boolean) {
                 expect(callOrder).to.deep.equal(['rollback-2', 'rollback-1']);
                 expect(warnSpy).toHaveBeenCalledOnce();
                 warnSpy.mockRestore();
+            });
+
+            it(`${testPrefix(shadow)}Should not expose rollback stack when state became unsafe before supported result.`, async () => {
+                const initialTarget = createTarget(shadow);
+                const newTarget = createTarget(shadow);
+                const rollback = vi.fn().mockResolvedValue(undefined);
+                const customRelocate = vi.fn().mockRejectedValue(new Error('custom-boom'));
+                const piece = {
+                    mount: vi.fn(),
+                    relocate: [
+                        vi.fn().mockResolvedValue(['supported', rollback]),
+                        vi.fn().mockResolvedValue('done')
+                    ]
+                };
+
+                const mp = new MountedPiece(piece, mountPieceCore);
+                await mp[mountKey](initialTarget);
+
+                await expect(mp.relocate(initialTarget, newTarget, customRelocate)).rejects.toThrow('custom-boom');
+                expect(customRelocate).toHaveBeenCalledOnce();
+                expect(rollback).not.toHaveBeenCalled();
             });
         });
         describe(`${testPrefix(shadow)}Capabilities`, () => {

--- a/tests/ut/index.test.ts
+++ b/tests/ut/index.test.ts
@@ -9,6 +9,7 @@ describe('index', () => {
             'ensureGlobalCollageJs',
             'preventRemount',
             'noopPiece',
+            'Stack',
         ];
         expect(Object.keys(CollageCore)).toEqual(expect.arrayContaining(expectedObjects));
         expect(expectedObjects).toEqual(expect.arrayContaining(Object.keys(CollageCore)));


### PR DESCRIPTION
Closes #32.